### PR TITLE
Use cache busting for APT update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,18 @@
 FROM ubuntu:20.04
 
 
-WORKDIR /gusApp
 WORKDIR /gusApp/project_home
 
-RUN apt-get -qq update --fix-missing
 
 # Installing Software
-RUN DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y \
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y \
     wget \
     openjdk-8-jdk \
     python3-pip \
     git \
-    trimmomatic=0.39+dfsg-1
+    trimmomatic=0.39+dfsg-1 \
+ && rm -rf /var/lib/apt/lists/*
 
 RUN pip3 install cython==0.29.30
 RUN pip3 install numpy==1.23.1


### PR DESCRIPTION
The apt-get update should be in the same layer as the installation to prevent Docker cache issues. I also purge the APT cache within the same layer to reduce image/layer size and I’ve removed an unneeded WORKDIR directive.
